### PR TITLE
Add unscoped variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,13 @@
 
 ![Travis](https://img.shields.io/travis/ukitgroup/nestjs-config/master.svg?style=flat-square)
 ![Coverage Status](https://coveralls.io/repos/github/ukitgroup/nestjs-config/badge.svg?branch=master)
-![node](https://img.shields.io/node/v/@ukitgroup/nestjs-config.svg?style=flat-square)
 ![npm](https://img.shields.io/npm/v/@ukitgroup/nestjs-config.svg?style=flat-square)
 
 ![GitHub top language](https://img.shields.io/github/languages/top/ukitgroup/nestjs-config.svg?style=flat-square)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/ukitgroup/nestjs-config.svg?style=flat-square)
-![David](https://img.shields.io/david/ukitgroup/nestjs-config.svg?style=flat-square)
-![David](https://img.shields.io/david/dev/ukitgroup/nestjs-config.svg?style=flat-square)
 
 ![license](https://img.shields.io/github/license/ukitgroup/nestjs-config.svg?style=flat-square)
 ![GitHub last commit](https://img.shields.io/github/last-commit/ukitgroup/nestjs-config.svg?style=flat-square)
-![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)
-
-## Description
 
 ### Convenient modular config for [`nestjs`](https://github.com/nestjs/nest) applications
 
@@ -93,11 +87,11 @@ ConfigModule.forRoot(options: ConfigOptions)
 ```
 
 ```typescript
-ConfigOptions: {
-  fromFile?: string,
-  configs?: ClassType[],
-  imports?: NestModule[],
-  providers?: Provider[],
+interface ConfigOptions {
+  fromFile?: string;
+  configs?: ClassType[];
+  imports?: NestModule[];
+  providers?: Provider[];
 }
 ```
 
@@ -128,20 +122,20 @@ ConfigModule.forFeature(configs: ClassType[])
 ### Decorators
 
 | Decorator                           | Description                                                                                                                      |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Common config decorators**        |                                                                                                                                  |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| **Common config decorators**        | Import from `@ukitgroup/nestjs-config`                                                                                           |
 | `@Config(name: string)`             | Add prefix to env variables                                                                                                      |
-| `@Env(name: string)`                | Extract env with `name` to this varaible                                                                                         |
+| `@UnscopedConfig()`                 | For config without prefix in env variables names                                                                                 |
+| `@Env(name: string)`                | Extract env with `name` to this variable                                                                                         |
 |                                     |                                                                                                                                  |
 | **Type decorators**                 | Import from `@ukitgroup/nestjs-config/types`                                                                                     |
 | `@String()`                         | String variable (`@IsString`)                                                                                                    |
-| `@Number()`                         | Number variable (`parseFloat` + `@IsNumber`                                                                                      |
-| `@Integer()`                        | Integer variable (`parseInt` + `@IsInteger`                                                                                      |
-| `@Boolean()`                        | Boolean variable ('true','false' + @IsBool`)                                                                                     |
+| `@Number()`                         | Number variable (`parseFloat` + `@IsNumber`)                                                                                     |
+| `@Integer()`                        | Integer variable (`parseInt` + `@IsInteger`)                                                                                     |
+| `@Boolean()`                        | Boolean variable ('true', 'false' + `@IsBool`)                                                                                   |
 | `@Transform(transformFn: Function)` | Custom transformation. Import from `@ukitgroup/nestjs-config/transformer`                                                        |
 |                                     |                                                                                                                                  |
 | **Validation decorators**           | The same as [`class-validator`](https://github.com/typestack/class-validator). Import from `@ukitgroup/nestjs-config/validator`. |
-
 
 ## Usage
 
@@ -283,7 +277,24 @@ or on launch your application
 APP__HTTP_PORT=3000 CAT__NAME=vasya CAT__WEIGHT=5 node dist/main.js
 ```
 
-Also you can see the example on github
+Also you can see the [example](./e2e-test) on GitHub.
+
+## Unscoped configs
+
+> Okay, that's cool, but what if I need more flexibility in environment variables? For example, we migrate from legacy service, and we need to use old variables names (without module__ prefix).
+
+I don't think this approach is quite right, try not to use it, but... we have `@UnscopedConfig` decorator instead of `@Config` for this case. But really, try to use `@Config` decorator first 🙂
+
+For example, we have env key `LEGACY_VARIABLE`, then config will be similar to this:
+
+```typescript
+@UnscopedConfig()
+export class LegacyConfig {
+  @Env('LEGACY_VARIABLE')
+  @String()
+  readonly fieldOne: string;
+}
+```
 
 ## Transformation
 
@@ -326,8 +337,8 @@ Library will throw an error on launch application: `Cat.weight received 'not_a_n
 
 ## Requirements
 
-1. @nestjs/common ^7.2.0
-2. @nestjs/core ^7.2.0
+1. @nestjs/common >=7.2.0
+2. @nestjs/core >=7.2.0
 
 ## License
 

--- a/e2e-test/dummy.e2e-spec.ts
+++ b/e2e-test/dummy.e2e-spec.ts
@@ -1,5 +1,0 @@
-describe('dummy e2e test', () => {
-  it('true tobe true', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/e2e-test/file.e2e-spec.ts
+++ b/e2e-test/file.e2e-spec.ts
@@ -45,7 +45,9 @@ describe('File', () => {
     })
     class AppModule {}
 
-    const app = await NestFactory.createApplicationContext(AppModule);
+    const app = await NestFactory.createApplicationContext(AppModule, {
+      bufferLogs: true,
+    });
 
     const firstConfig = app.get<FirstConfig>(FirstConfig);
     const secondConfig = app.get<SecondConfig>(SecondConfig);

--- a/e2e-test/process.e2e-spec.ts
+++ b/e2e-test/process.e2e-spec.ts
@@ -24,7 +24,9 @@ describe('Process', () => {
     })
     class AppModule {}
 
-    const app = await NestFactory.createApplicationContext(AppModule);
+    const app = await NestFactory.createApplicationContext(AppModule, {
+      bufferLogs: true,
+    });
 
     const firstConfig = app.get<FirstConfig>(FirstConfig);
     const secondConfig = app.get<SecondConfig>(SecondConfig);

--- a/e2e-test/raw.e2e-spec.ts
+++ b/e2e-test/raw.e2e-spec.ts
@@ -32,7 +32,9 @@ describe('Raw', () => {
     })
     class AppModule {}
 
-    const app = await NestFactory.createApplicationContext(AppModule);
+    const app = await NestFactory.createApplicationContext(AppModule, {
+      bufferLogs: true,
+    });
 
     const firstConfig = app.get<FirstConfig>(FirstConfig);
     const secondConfig = app.get<SecondConfig>(SecondConfig);

--- a/e2e-test/unscoped.e2e-spec.ts
+++ b/e2e-test/unscoped.e2e-spec.ts
@@ -1,0 +1,39 @@
+/* eslint-disable max-classes-per-file */
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { ConfigModule, UnscopedConfig, Env } from '../src';
+import { String } from '../src/types';
+
+describe('UnscopedConfig', () => {
+  @UnscopedConfig()
+  class TestUnscopedConfig {
+    @Env('SOME_UNSCOPED_VARIABLE')
+    @String()
+    stringVar: string;
+  }
+
+  @Module({
+    imports: [ConfigModule.forRoot({ configs: [TestUnscopedConfig] })],
+  })
+  class AppModule {}
+
+  beforeAll(() => {
+    Object.assign(process.env, {
+      SOME_UNSCOPED_VARIABLE: 'stringVarOfSomeVariableOutOfModuleScope',
+    });
+  });
+
+  it('should successfully map envs out of module scope', async () => {
+    const app = await NestFactory.createApplicationContext(AppModule, {
+      bufferLogs: true,
+    });
+
+    const testConfig = app.get<TestUnscopedConfig>(TestUnscopedConfig);
+
+    expect(testConfig).toMatchObject({
+      stringVar: 'stringVarOfSomeVariableOutOfModuleScope',
+    });
+
+    await app.close();
+  });
+});

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,10 +1,17 @@
 import { Expose } from './transformer';
-import { ENV_CONFIG_NAME_SYMBOL } from './lib/symbols';
+import { ENV_CONFIG_NAME_SYMBOL, UNSCOPED_CONFIG_SYMBOL } from './lib/symbols';
 
 export function Config(name: string): ClassDecorator {
   return (target: Function): void => {
     // eslint-disable-next-line no-param-reassign
     target[ENV_CONFIG_NAME_SYMBOL] = name;
+  };
+}
+
+export function UnscopedConfig(): ClassDecorator {
+  return (target: Function): void => {
+    // eslint-disable-next-line no-param-reassign
+    target[UNSCOPED_CONFIG_SYMBOL] = true;
   };
 }
 

--- a/src/dummy.spec.ts
+++ b/src/dummy.spec.ts
@@ -1,5 +1,0 @@
-describe('dummy unit test', () => {
-  it('true tobe true', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/src/lib/factory.spec.ts
+++ b/src/lib/factory.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigFactory } from './factory';
-import { Config, Env } from '../decorator';
+import { Config, Env, UnscopedConfig } from '../decorator';
 import { Boolean, Integer, Number, String } from '../types';
+import { UNSCOPED_CONFIG_SYMBOL } from './symbols';
 
 describe('ConfigFactory', () => {
   const configFactory = new ConfigFactory();
@@ -33,6 +34,48 @@ describe('ConfigFactory', () => {
       ).toMatchObject({
         [variableName]: newValue,
       });
+    });
+  });
+
+  describe('Unscoped config', () => {
+    const variableName = 'variable';
+    const envVariableName = 'UNSCOPED_VARIABLE';
+    const value = 'value from env';
+
+    @UnscopedConfig()
+    class TestConfig {
+      @Env(envVariableName)
+      @String()
+      [variableName]: string;
+    }
+
+    it('should return config with raw mapping without prefix', () => {
+      expect(
+        configFactory.createConfig(
+          {
+            [UNSCOPED_CONFIG_SYMBOL]: {
+              [envVariableName]: value,
+            },
+          },
+          TestConfig,
+        ),
+      ).toMatchObject({
+        [variableName]: value,
+      });
+    });
+
+    it('should return config without extraneous envs', () => {
+      expect(
+        configFactory.createConfig(
+          {
+            [UNSCOPED_CONFIG_SYMBOL]: {
+              [envVariableName]: value,
+              EXTRANEOUS_ENV: 'extraneous value',
+            },
+          },
+          TestConfig,
+        ),
+      ).not.toHaveProperty('EXTRANEOUS_ENV');
     });
   });
 

--- a/src/lib/factory.ts
+++ b/src/lib/factory.ts
@@ -1,5 +1,5 @@
 import { ClassType, ConfigStorage } from './types';
-import { ENV_CONFIG_NAME_SYMBOL } from './symbols';
+import { ENV_CONFIG_NAME_SYMBOL, UNSCOPED_CONFIG_SYMBOL } from './symbols';
 import { plainToClass } from '../transformer';
 
 export class ConfigFactory {
@@ -7,6 +7,12 @@ export class ConfigFactory {
     configStorage: ConfigStorage,
     ConfigClass: ClassType,
   ): typeof ConfigClass.prototype {
+    if (ConfigClass[UNSCOPED_CONFIG_SYMBOL]) {
+      return plainToClass(ConfigClass, configStorage[UNSCOPED_CONFIG_SYMBOL], {
+        excludeExtraneousValues: true,
+      });
+    }
+
     let name = ConfigClass[ENV_CONFIG_NAME_SYMBOL];
     if (!name) {
       // TODO: warning

--- a/src/lib/parser.spec.ts
+++ b/src/lib/parser.spec.ts
@@ -1,33 +1,38 @@
 import { ConfigParser, ENV_MODULE_SEPARATOR } from './parser';
+import { UNSCOPED_CONFIG_SYMBOL } from './symbols';
 
 describe('ConfigParser', () => {
   const configParser = new ConfigParser();
 
-  it('should return empty object if nothing provided', () => {
-    expect(configParser.parse({})).toMatchObject({});
+  it('should return object only with raw envs if nothing provided', () => {
+    expect(configParser.parse({})).toMatchObject({
+      [UNSCOPED_CONFIG_SYMBOL]: {},
+    });
   });
 
-  it('should return empty object if module not provided', () => {
-    expect(
-      configParser.parse({
-        SOME_VARIABLE: 'some value',
-      }),
-    ).toMatchObject({});
+  it('should return object only with raw envs if module not provided', () => {
+    const env = {
+      SOME_VARIABLE: 'some value',
+    };
+
+    expect(configParser.parse(env)).toMatchObject({
+      [UNSCOPED_CONFIG_SYMBOL]: env,
+    });
   });
 
   it('should return values to override module config defaults', () => {
     const moduleName = 'SOME_MODULE';
     const variableName = 'SOME_VARIABLE';
     const value = 'some value';
+    const env = {
+      [`${moduleName}${ENV_MODULE_SEPARATOR}${variableName}`]: value,
+    };
 
-    expect(
-      configParser.parse({
-        [`${moduleName}${ENV_MODULE_SEPARATOR}${variableName}`]: value,
-      }),
-    ).toMatchObject({
+    expect(configParser.parse(env)).toMatchObject({
       [moduleName]: {
         [variableName]: value,
       },
+      [UNSCOPED_CONFIG_SYMBOL]: env,
     });
   });
 

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,10 +1,13 @@
 import { ConfigStorage, ProcessEnv } from './types';
+import { UNSCOPED_CONFIG_SYMBOL } from './symbols';
 
 export const ENV_MODULE_SEPARATOR = '__';
 
 export class ConfigParser {
   public parse(processEnv: ProcessEnv): ConfigStorage {
-    const configStorage: ConfigStorage = {};
+    const configStorage: ConfigStorage = {
+      [UNSCOPED_CONFIG_SYMBOL]: processEnv,
+    };
     Object.entries(processEnv).forEach(
       ([variable, value]: [string, string]) => {
         const split = variable.split(ENV_MODULE_SEPARATOR);

--- a/src/lib/symbols.ts
+++ b/src/lib/symbols.ts
@@ -1,1 +1,2 @@
 export const ENV_CONFIG_NAME_SYMBOL = Symbol.for('ENV_CONFIG_NAME');
+export const UNSCOPED_CONFIG_SYMBOL = Symbol.for('UNSCOPED_ENV_CONFIG');

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,7 +4,7 @@ export declare type ClassType = {
 };
 
 export type ConfigStorage = {
-  [name: string]:
+  [name: string | symbol]:
     | string
     | {
         [name: string]: string | number | boolean;


### PR DESCRIPTION
I want add ability to map raw variables without `MODULE__` prefix for simplify migration.

In this case config definition will be similar to this:
```typescript
@UnscopedConfig()
export class LegacyConfig {
  @Env('LEGACY_VARIABLE')
  @String()
  readonly fieldOne: string;
}
```

For details see changes in README and e2e tests.
